### PR TITLE
centering scroll content if it is smaller than the destination size

### DIFF
--- a/RSMoveAndScaleController.m
+++ b/RSMoveAndScaleController.m
@@ -133,6 +133,16 @@
 	
 	offset.y = MAX(MIN(offset.y, t.y), -threshold.y);
 	offset.x = MAX(MIN(offset.x, t.x), -threshold.x);
+    
+    //center items if they are smaller than destination size
+    if (self.destinationSize.width > size.width) {
+        offset.x -= roundf((self.destinationSize.width - size.width)/2);;
+    }
+    
+    if (self.destinationSize.height > size.height) {
+        offset.y -= roundf((self.destinationSize.height - size.height)/2);;
+    }
+    
 	_scrollView.contentOffset = offset;
 	_scrollView.contentInset = UIEdgeInsetsMake(-offset.y, -offset.x, 0, 0);
 }


### PR DESCRIPTION
All functionality remains the same, just centers the preview image inside of the destination size frame. 
