### PR TITLE
centering scroll content if it is smaller than the destination size

### DIFF
--- a/RSMoveAndScaleController.m
+++ b/RSMoveAndScaleController.m
@@ -131,8 +131,8 @@
 	//	NSLog(@"scale %f offset:%@", scale, NSStringFromCGPoint(offset));
 	CGPoint t = scale == 1 ? threshold : CGPointMake(threshold.x + size.width * scale, threshold.y + size.height * scale);
 
-	offset.y = MAX(MIN(offset.y, t.y), - threshold.y);
-	offset.x = MAX(MIN(offset.x, t.x), - threshold.x);
+	offset.y = MAX(MIN(offset.y, t.y), -threshold.y);
+	offset.x = MAX(MIN(offset.x, t.x), -threshold.x);
 
 	//center items if they are smaller than destination size
 	if (self.destinationSize.width > size.width) {


### PR DESCRIPTION
Hey Rex resubmitting with a few notes:
1. Current functionality is not what is expected.
2. Images are aligned to an axis which leads to bad user interaction.

There is no simple change that will give the correct behavior (e.g. just changing content mode). @lickel and I discussed possibly exposing alignment options as a delegate protocol but ultimately didn't think that was the right solution.

The style changes you pointed out have been fixed, sorry about that. Please try this out on device with the current and suggested implementations, I think you'll agree that this is the more desirable behavior. 

If you feel there is a better implementation to achieve this functionality let's discuss. 

Thanks. 
